### PR TITLE
Add chief-loop and loop-readiness skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -20,9 +20,11 @@
         "./skills/chief/chief-retro",
         "./skills/chief/chief-rule",
         "./skills/chief/chief-grill",
+        "./skills/chief/chief-loop",
         "./skills/engineering/shape-up",
         "./skills/engineering/grill-design",
         "./skills/engineering/slim-down",
+        "./skills/engineering/loop-readiness",
         "./skills/misc/dump-commit"
       ]
     }

--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ Best for prototyping, well-defined goals, solo work.
 | `/chief-init`      | Bootstrap `.chief/project.md` via interview                            |
 | `/chief-plan`      | Plan a milestone: grill → goals → contracts → tasks                   |
 | `/chief-autopilot` | Run a milestone autonomously                                             |
+| `/chief-loop`      | Run chief-agent across a full milestone, batch after batch, with a report per task |
 | `/chief-grill`     | Deep stateful stress-test; spawns `answer-verifier-agent` per question |
 | `/chief-rule`      | Capture a decision as a permanent rule in `_rules/`                    |
 | `/chief-retro`     | Retrospective + lesson learned +`_rules/` update                       |
 | `/grill-design`    | Stateless design stress-test with self-critique                          |
 | `/shape-up`        | Turn a fuzzy idea into a scoped spec (top-down)                          |
 | `/slim-down`       | Cut a scope that's too large into a phase-sized piece                    |
+| `/loop-readiness`  | Review whether a plan is ready to run as an unattended loop              |
 | `/dump-commit`     | Quick clean commit with auto-generated message                           |
 
 → [Full skills reference](docs/manual/reference/skills.md)
@@ -162,7 +164,7 @@ Full documentation lives in [`docs/manual/`](docs/manual/):
 - **v1** — Initial release, Claude Code support. [docs](https://github.com/thaitype/chief-agent-framework/tree/release/v1)
 - **v2** — Multi-agent support, skills system. [docs](https://github.com/thaitype/chief-agent-framework/tree/release/v2)
 - **v3** — Rebranded to Chief. `chief-` skill prefix. Repo moved to [`thaitype/chief`](https://github.com/thaitype/chief).
-- **v4** — Skills via `npx skills` (decoupled from install). Lazy `.chief/`. New skills: `/chief-init`, `/chief-rule`, `/chief-grill`, `/grill-design`, `/shape-up`, `/slim-down`. `answer-verifier-agent` replaces deprecated `review-plan-agent`.
+- **v4** — Skills via `npx skills` (decoupled from install). Lazy `.chief/`. New skills: `/chief-init`, `/chief-rule`, `/chief-grill`, `/grill-design`, `/shape-up`, `/slim-down`, `/chief-loop`, `/loop-readiness`. `answer-verifier-agent` replaces deprecated `review-plan-agent`.
 
 ## Branches
 

--- a/docs/manual/how-to/pick-the-right-skill.md
+++ b/docs/manual/how-to/pick-the-right-skill.md
@@ -38,9 +38,11 @@ You have a problem or vision but haven't turned it into concrete requirements. `
 |---|---|
 | Plan a milestone step by step | `/chief-plan` |
 | Run a milestone hands-off | `/chief-autopilot` |
+| Run a full milestone across many batches, one report per task | `/chief-loop` |
 | Stress-test a design before building | `/chief-grill` or `/grill-design` |
 | Turn a vague idea into a spec | `/shape-up` |
 | Cut a goal down to a manageable phase | `/slim-down` |
+| Check a plan is safe to run unattended | `/loop-readiness` |
 | Permanently capture a decision as a rule | `/chief-rule` |
 | Bootstrap project context once | `/chief-init` |
 | Review a milestone after it ships | `/chief-retro` |
@@ -72,6 +74,14 @@ Use `/grill-design` for smaller ideas where you don't need audit trail or codeba
 | Best for | Complex projects, team work, unfamiliar domains | Prototyping, well-defined goals, solo work |
 
 You can combine: plan carefully with `/chief-plan`, then execute with `/chief-autopilot`.
+
+---
+
+## Choosing between `/chief-autopilot` and `/chief-loop`
+
+`/chief-loop` builds directly on `/chief-autopilot`'s auto mode — same no-stopping-for-ambiguity behavior, but it spans as many batches as it takes to finish the milestone (not just one), and writes a report per task instead of one per batch. Use `/loop-readiness` first if the milestone is large or touches anything you'd want a real-environment check on before letting it run unattended for that long.
+
+If you want the "stop and ask a human on ambiguity" behavior, use `/chief-autopilot safe` instead — `/chief-loop` has no safe-mode equivalent.
 
 ---
 

--- a/docs/manual/reference/skills.md
+++ b/docs/manual/reference/skills.md
@@ -44,6 +44,16 @@ Recommended only when the goal is clear and well-scoped. Not recommended for lar
 
 ---
 
+### `/chief-loop`
+
+Runs chief-agent across as many batches as it takes to finish a milestone — batch after batch, no cap — writing one report per task instead of one per batch.
+
+Builds directly on `/chief-autopilot`'s auto mode: no stopping for human input on ambiguity. When a task hits ambiguity, a throwaway decision-support agent proposes 2–3 options; chief-agent still makes the final call, and the reasoning is recorded in that task's report. Requires goals and contracts to exist.
+
+If you want the "stop and ask a human" behavior instead, use `/chief-autopilot safe`.
+
+---
+
 ### `/chief-grill`
 
 Stateful, deep stress-test of a design or decision. Spawns `answer-verifier-agent` per question.
@@ -105,6 +115,16 @@ Use when you have a problem or idea but not yet a concrete requirement.
 Reduces a goal or spec that's too large for a single milestone.
 
 After writing goals, if the scope is too big, `/slim-down` trims it to a phase-sized piece, preserving the rest for a future milestone.
+
+---
+
+### `/loop-readiness`
+
+Reviews whether a plan is ready to run as an unattended loop — an autopilot, scheduled job, or long-running agent workflow with no human checking every step.
+
+Checks four dimensions: Definition of Ready, feedforward guidance, feedback/verification, and Definition of Done. Reports what's present, missing, and partial per dimension — no pass/fail verdict or single score. Nothing gets executed; this is a static review of the plan as described.
+
+Works from an existing plan file or by interviewing you (via `/grill-design` if available). Useful before `/chief-loop` or `/chief-autopilot` on a milestone that will run many iterations unattended.
 
 ---
 

--- a/skills/chief/chief-loop/SKILL.md
+++ b/skills/chief/chief-loop/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: chief-loop
+description: Run chief-agent across as many batches as it takes to finish a milestone, writing one report per task instead of one per batch. When a task hits ambiguity, a throwaway decision-support agent proposes options; chief-agent still makes the final call and the report captures the reasoning. Requires goals and contracts to exist. Use "/chief-loop".
+---
+
+Run chief-agent across the full milestone — batch after batch — until both the goals and
+the contracts are satisfied, recording a decision-aware report for every task instead of
+one combined report per batch.
+
+This builds directly on `chief-autopilot`'s auto mode. If you want the "stop and ask a
+human on ambiguity" behavior, use `chief-autopilot safe` instead — `chief-loop` only runs
+in auto mode; it doesn't have a safe-mode equivalent.
+
+## Prerequisite Check
+
+Before doing anything:
+
+1. Identify the active milestone directory under `.chief/`.
+2. Check that `_goal/` has at least one non-empty file.
+3. Check that `_contract/` has at least one non-empty file.
+
+If either is missing → **STOP**. Tell the user:
+> "Goals and contracts are required for chief-loop. Run `/chief-plan` first."
+
+Do NOT proceed.
+
+## Entry Confirmation
+
+Present the current goals and contracts to the user in a brief summary (file names + 1-line description each).
+
+Ask one question:
+> "Goals and contracts look correct? Proceed with chief-loop, or use `/chief-plan` to revise first?"
+
+If the user says revise → stop.
+If the user confirms → proceed.
+
+**Optional:** if the `loop-readiness` skill is available, offer to run it against this
+milestone's plan before proceeding — it reviews whether the plan has enough
+feedforward/feedback coverage to run safely unattended. This is a suggestion, not a
+requirement; proceed without it if the user declines.
+
+## Outer Loop (spans as many batches as it takes)
+
+### 1. Create or update TODO
+
+Read existing `_plan/_todo.md` if present. Create the next batch of 3–5 tasks based on
+goals, contracts, and what's already done — same small-batches principle as
+`chief-autopilot`.
+
+Write `_plan/_todo.md`. Do NOT wait for approval — this is autopilot-style, no pausing
+for plan review.
+
+### 2. Work the batch, one task at a time
+
+For each uncompleted task in the current batch:
+
+1. Delegate to builder-agent with:
+   - The TODO entry
+   - Milestone goals (`_goal/`)
+   - Milestone contracts (`_contract/`)
+   - Relevant global rules (`.chief/_rules/`)
+   - Verification expectations
+2. Wait for builder to complete.
+3. If builder reports a blocker or ambiguity, see **Handling Ambiguity** below before
+   moving on.
+4. Mark the task `[x]` in `_todo.md`.
+5. Write that task's report (see **Task Report** below) — do this immediately, before
+   starting the next task. Don't batch report-writing up to the end.
+
+### 3. Check for milestone completion
+
+After the batch is fully worked:
+- If the goals aren't fully met, or the implementation doesn't yet satisfy the
+  contracts → go back to step 1 and create the next batch.
+- If both goals and contracts are satisfied → stop. The milestone is done.
+
+There's no cap on how many batches this takes — keep going until both conditions hold.
+
+## Handling Ambiguity
+
+When builder-agent reports a blocker or ambiguity on a task:
+
+1. Spawn a **throwaway agent** (a plain `Agent` tool call — not a persistent agent type)
+   with a self-contained prompt: describe the ambiguity, the options it's aware of, and
+   ask it to propose 2–3 concrete options with a one-line trade-off each. This agent's
+   only job is to help think through the options — it does not decide, and it does not
+   write any files.
+2. chief-agent reviews the proposed options and **picks one itself** — chief-agent is
+   always the final decision-maker, same as in `chief-autopilot`.
+3. Record the issue, the options considered, and the choice + reasoning in that task's
+   report (see below).
+
+If a task has no ambiguity, skip this section entirely — no agent gets spawned, and the
+task's report is just a short, factual summary.
+
+## Task Report
+
+For every task (not just the ones with ambiguity), write:
+
+`.chief/<milestone>/_report/task-<task-id>-report.md`
+
+Using the same `<task-id>` as `_plan/task-<task-id>.md`, so the two files map 1:1.
+
+```md
+# Task <task-id> Report
+
+## Task
+One or two lines on what this task was.
+
+## Outcome
+done | blocked
+
+## Decision
+(Omit this whole section if the task had no ambiguity.)
+- **Issue:** what was ambiguous or blocking
+- **Options considered:** the options the decision-support agent proposed
+- **Chosen:** which one, and why
+
+## Notes
+Anything worth carrying into the next task or batch.
+```
+
+## Rules
+
+- NEVER start without goals and contracts existing.
+- NEVER skip the entry confirmation.
+- NEVER stop for human input on ambiguity — this skill only has an auto-mode-like
+  behavior. Point the user at `chief-autopilot safe` if they want stop-and-ask.
+- chief-agent is ALWAYS the one who makes the final decision on an ambiguity — the
+  decision-support agent only proposes options, never decides, never writes files.
+- Write a report for every task, immediately after that task completes — never batch
+  report-writing up.
+- Keep the small-batches principle (3–5 tasks per TODO cycle) — only the report
+  granularity changed, not the planning cadence.
+- Milestone completion requires BOTH goals met AND contracts satisfied — meeting the
+  goal alone isn't enough to stop.
+- Builder-agent handles all implementation. Chief NEVER writes code.
+- Tester-agent is NOT used unless the user explicitly requests it.

--- a/skills/engineering/loop-readiness/SKILL.md
+++ b/skills/engineering/loop-readiness/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: loop-readiness
+description: Review the readiness of a plan for an unattended/autonomous loop — checks whether it has enough feedforward guidance and feedback verification to run safely. Use when the user has a plan (or an idea) for a loop/agent that will run multiple iterations without a human checking every step, and wants to know how well-instrumented it is before starting. Works from an existing plan file or from a live conversation.
+---
+
+# Loop readiness review
+
+This is a **readiness review**, not a gate. It never produces a pass/fail verdict or a
+single overall score — it reports what's present, what's missing, and what to consider
+per dimension, so the person deciding whether to start the loop has the full picture.
+
+A "loop" here means any agent/process that runs multiple iterations with **no human
+checking every step** — an autopilot, a scheduled job, a long-running agent workflow, or
+anything similar. The review looks at the *plan* for that loop, not the loop itself —
+nothing gets executed during this review.
+
+## Step 1: Get the plan
+
+- If a plan was given — as text or a file path — use it.
+- If not, use the `grill-design` skill if available. Otherwise, **interview the user
+  one question at a time** to build up an understanding of the plan — what it's trying
+  to do, and how it's supposed to know if it's working. One question per turn, never
+  ask a compound question.
+
+## Step 2: Review each dimension
+
+Walk through all four. For each, note what's present, what's missing, and how deep the
+coverage is — there's no fixed checklist to fill in mechanically; use judgment about how
+much depth this specific loop actually needs.
+
+### 2.1 Definition of Ready (DoR)
+
+Is there something written down that defines what this loop is for and where its edges
+are? Depending on the loop, this could include: a goal statement, explicit non-goals /
+out-of-scope items, a contract (data shapes, API boundaries), a UI mock or diagram — go
+as deep as makes sense for the stakes involved. A one-line goal can be enough for a small
+loop; a loop that touches production data probably needs more.
+
+### 2.2 Feedforward
+
+Feedforward is guidance given to the loop *before or during* each iteration, to raise the
+odds it does the right thing in the first place — conventions docs, skills, contracts,
+bootstrap scripts, code-mod tooling, anything the loop reads or is constrained by while
+acting. Note whether this guidance is:
+- **Computational** — a deterministic tool/script/generator it must go through
+- **Inferential** — a doc/skill it reads and applies judgment to
+- Both, or neither
+
+### 2.3 Feedback
+
+Feedback is verification *after* an iteration/action, to catch bad outcomes. A healthy
+loop usually needs at least one kind, but which kinds and how many is a judgment call
+based on what the loop can actually break. Look for:
+
+- **Computational / mock / dry-run** — unit tests, linters, type checks, structural
+  checks. Cheap and fast, run on every iteration, but can pass while missing real-world
+  failures — note this trade-off if it's the *only* feedback mechanism present.
+- **Real-environment** — verification against the actual system the loop will operate
+  on. Note whether it exists, and whether it looks safe to run unattended (see the
+  concrete checks under Step 3 — they apply here).
+- **Inferential** — an LLM-as-judge or review step that makes a semantic judgment call
+  on the outcome, rather than a deterministic check.
+
+### 2.4 Definition of Done (DoD)
+
+Does the plan say how the loop actually stops? There's no required vocabulary or fixed
+set of terminal states — a loop can end however its author defines. Note whether the
+plan accounts for more than just a clean success path: what happens on failure, and what
+happens if the loop can't tell whether it succeeded (ambiguous outcome, missing
+precondition, etc.) — these are worth surfacing as a gap if absent, without requiring
+any particular fix.
+
+## Step 3: Report
+
+For each of the 4 dimensions above, produce:
+- a short checklist of what's present / missing / partial
+- a one-line qualitative note for that dimension only (e.g. "solid", "thin", "missing")
+
+Do **not** synthesize these into one overall score or label — the four notes stand on
+their own; the reader weighs them.
+
+Then add **actionable recommendations** tied to the specific gaps found — concrete next
+steps, not just "this is missing." For any real-environment feedback found in 2.3, check
+directly (this is static-review-friendly — usually a clear yes/no from the plan as
+described) and recommend fixes for whichever are missing:
+- Is there a **preflight step** that verifies credentials/permissions actually work
+  *before* the loop starts doing real work (not just assumed to work)? If not, recommend
+  adding one — test against the real system once, before the loop runs unattended.
+- Is access **least-privilege** scoped — no broader than the task needs? If not,
+  recommend narrowing it.
+- Is it **read-only by default**? If the loop only needs to observe but holds write
+  access anyway, recommend dropping it.
+- If the loop genuinely needs to write, is that write scoped to an environment that's
+  actually safe to write to (a sandbox, a non-production target, or similar) rather than
+  a write capability bolted onto a read-oriented check? If not, recommend fixing the
+  scope before the loop runs unattended.
+
+Other recommendation examples:
+- Nothing written down about the loop's goal or edges (DoR) → recommend writing at least
+  a one-line goal and explicit non-goals before starting, so scope doesn't drift mid-run
+- No guidance/conventions for the loop to follow (Feedforward) → recommend pointing it at
+  existing docs/skills/contracts, or writing a short one if none exist
+- Only mock/dry-run feedback, nothing against the real target → recommend adding at
+  least one real-environment check, or explicitly accepting the risk if the loop's
+  stakes are low
+- No escalation/blocked outcome in the DoD → recommend adding a defined way for the loop
+  to stop and hand off to a human when it can't tell if it succeeded
+
+Recommendations are suggestions to weigh, not requirements to satisfy before proceeding.
+
+## Rules
+
+- NEVER execute anything from the plan being reviewed — this is a static review of what's
+  described, not a test of whether it actually works.
+- NEVER produce a pass/fail verdict or a single overall score/label — dimension-level
+  notes only.
+- NEVER require a specific vocabulary for DoD terminal states or a fixed checklist for
+  DoR — assess what's there against what this specific loop's stakes call for.
+- NEVER write to any other file — like a grill session, this review lives in the
+  conversation (or is returned as a response), unless the user explicitly asks for it to
+  be saved somewhere.


### PR DESCRIPTION
## Summary
- New `/chief-loop` skill: runs chief-agent across a full milestone, batch after batch, writing one report per task with decision-support agent help on ambiguity
- New `/loop-readiness` skill: static readiness review for plans meant to run as unattended loops

## Test plan
- [x] `npx skills@latest add thaitype/chief#main.loop` in a test project and confirm `/chief-loop` and `/loop-readiness` install and run

🤖 Generated with [Claude Code](https://claude.com/claude-code)